### PR TITLE
Fix for sending of shipping tracking number to Amazon from old Magento

### DIFF
--- a/app/code/community/Ess/M2ePro/Model/Order/Shipment/Handler.php
+++ b/app/code/community/Ess/M2ePro/Model/Order/Shipment/Handler.php
@@ -58,7 +58,7 @@ class Ess_M2ePro_Model_Order_Shipment_Handler
         $track = $shipment->getTracksCollection()->getLastItem();
         $trackingDetails = array();
 
-        $number = trim($track->getData('number'));
+        $number = trim($track->getNumber());
 
         if (!empty($number)) {
             $carrierCode = trim($track->getData('carrier_code'));


### PR DESCRIPTION
Back compatibility with old Magento versions. 

This fix exists in Magento core (file: app/code/core/Mage/Sales/Model/Order/Shipment/Track.php method getNumber()), just use $track->getNumber(); instead $track->getData('number');

Thanks!
