### PR TITLE
Added company data to magento customer

### DIFF
--- a/app/code/community/Ess/M2ePro/Model/Magento/Customer.php
+++ b/app/code/community/Ess/M2ePro/Model/Magento/Customer.php
@@ -50,6 +50,7 @@ class Ess_M2ePro_Model_Magento_Customer extends Mage_Core_Model_Abstract
             ->setData('postcode', $this->getData('postcode'))
             ->setData('telephone', $this->getData('telephone'))
             ->setData('street', $this->getData('street'))
+            ->setData('company', $this->getData('company'))
             ->setCustomerId($this->customer->getId())
             ->setIsDefaultBilling(true)
             ->setIsDefaultShipping(true);


### PR DESCRIPTION
Company data is missing when customers are created in Magento.

This was fixed for us on 16/07/24 , but it is still not in public releases.