### PR TITLE
replaced deprecated create_function calls with anonymous functions

### DIFF
--- a/app/code/community/Ess/M2ePro/Helper/Module/Exception.php
+++ b/app/code/community/Ess/M2ePro/Helper/Module/Exception.php
@@ -92,21 +92,21 @@ class Ess_M2ePro_Helper_Module_Exception extends Mage_Core_Helper_Abstract
 
         Mage::helper('M2ePro/Data_Global')->setValue('set_fatal_error_handler', true);
 
-        $functionCode = '$error = error_get_last();
+        $shutdownFunction = function () {
+            $error = error_get_last();
 
-                         if (is_null($error)) {
-                             return;
-                         }
+            if (is_null($error)) {
+                return;
+            }
 
-                         $fatalErrors = array(E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR);
+            $fatalErrors = array(E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR);
 
-                         if (in_array((int)$error[\'type\'], $fatalErrors)) {
-                             $trace = @debug_backtrace(false);
-                             $traceInfo = Mage::helper(\'M2ePro/Module_Exception\')->getFatalStackTraceInfo($trace);
-                             Mage::helper(\'M2ePro/Module_Exception\')->processFatal($error,$traceInfo);
-                         }';
-
-        $shutdownFunction = create_function('', $functionCode);
+            if (in_array((int)$error['type'], $fatalErrors)) {
+                $trace     = @debug_backtrace(false);
+                $traceInfo = Mage::helper('M2ePro/Module_Exception')->getFatalStackTraceInfo($trace);
+                Mage::helper('M2ePro/Module_Exception')->processFatal($error, $traceInfo);
+            }
+        };
         register_shutdown_function($shutdownFunction);
     }
 

--- a/app/code/community/Ess/M2ePro/Helper/Module/Wizard.php
+++ b/app/code/community/Ess/M2ePro/Helper/Module/Wizard.php
@@ -232,19 +232,17 @@ class Ess_M2ePro_Helper_Module_Wizard extends Mage_Core_Helper_Abstract
             $connRead->select()->from($tableName,'*')
         );
 
-        $sortFunction = <<<FUNCTION
-if (\$a['type'] != \$b['type']) {
-    return \$a['type'] == Ess_M2ePro_Helper_Module_Wizard::TYPE_BLOCKER ? - 1 : 1;
-}
+        $sortFunction = function ($a, $b) {
+            if ($a['type'] != $b['type']) {
+                return $a['type'] == Ess_M2ePro_Helper_Module_Wizard::TYPE_BLOCKER ? -1 : 1;
+            }
 
-if (\$a['priority'] == \$b['priority']) {
-    return 0;
-}
+            if ($a['priority'] == $b['priority']) {
+                return 0;
+            }
 
-return \$a['priority'] > \$b['priority'] ? 1 : -1;
-FUNCTION;
-
-        $sortFunction = create_function('$a,$b',$sortFunction);
+            return $a['priority'] > $b['priority'] ? 1 : -1;
+        };
 
         usort($this->cache, $sortFunction);
 

--- a/app/code/community/Ess/M2ePro/Model/Connector/ResponserRunner.php
+++ b/app/code/community/Ess/M2ePro/Model/Connector/ResponserRunner.php
@@ -155,12 +155,12 @@ class Ess_M2ePro_Model_Connector_ResponserRunner
 
         $table = Mage::getResourceModel('M2ePro/LockedObject')->getMainTable();
 
-        $functionCode = "Mage::getSingleton('core/resource')->getConnection('core_write')
-                            ->delete('".$table."',array('`related_hash` = ?'=>'".$hash."'));
-                         Mage::getSingleton('core/resource')->getConnection('core_write')
-                            ->delete('".$table."',array('`id` = ?'=>".$processingRequestId."));";
-
-        $shutdownDeleteFunction = create_function('', $functionCode);
+        $shutdownDeleteFunction = function () use ($table, $hash, $processingRequestId) {
+            Mage::getSingleton('core/resource')->getConnection('core_write')
+                ->delete($table, array('`related_hash` = ?' => $hash));
+            Mage::getSingleton('core/resource')->getConnection('core_write')
+                ->delete($table, array('`id` = ?' => ".$processingRequestId."));
+        };
         register_shutdown_function($shutdownDeleteFunction);
     }
 

--- a/app/code/community/Ess/M2ePro/Model/LockItem.php
+++ b/app/code/community/Ess/M2ePro/Model/LockItem.php
@@ -215,11 +215,11 @@ class Ess_M2ePro_Model_LockItem extends Ess_M2ePro_Model_Abstract
             return false;
         }
 
-        $functionCode = "\$object = Mage::getModel('M2ePro/LockItem');
-                         \$object->setNick('".$this->nick."');
-                         \$object->remove();";
-
-        $shutdownDeleteFunction = create_function('', $functionCode);
+        $shutdownDeleteFunction = function () {
+            $object = Mage::getModel('M2ePro/LockItem');
+            $object->setNick($this->nick);
+            $object->remove();
+        };
         register_shutdown_function($shutdownDeleteFunction);
 
         return true;

--- a/app/code/community/Ess/M2ePro/Model/OperationHistory.php
+++ b/app/code/community/Ess/M2ePro/Model/OperationHistory.php
@@ -132,38 +132,37 @@ class Ess_M2ePro_Model_OperationHistory extends Ess_M2ePro_Model_Abstract
             return false;
         }
 
-        $functionCode =
-            '$object = Mage::getModel(\'M2ePro/OperationHistory\');
-             $object->setObject('.$this->object->getId().');
+        $shutdownDeleteFunction = function () {
+            $object = Mage::getModel('M2ePro/OperationHistory');
+            $object->setObject($this->object->getId());
 
-             if (!$object->stop()) {
+            if (!$object->stop()) {
                 return;
-             }
+            }
 
-             $collection = $object->getCollection()
-                     ->addFieldToFilter(\'parent_id\', '.$this->object->getId().');
+            $collection = $object->getCollection()
+                ->addFieldToFilter('parent_id', $this->object->getId());
 
-             if ($collection->getSize()) {
+            if ($collection->getSize()) {
                 return;
-             }
+            }
 
-             $error = error_get_last();
+            $error = error_get_last();
 
-             if (is_null($error)) {
-                 return;
-             }
+            if (is_null($error)) {
+                return;
+            }
 
-             if (in_array((int)$error[\'type\'], array(E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR))) {
-                 $stackTrace = @debug_backtrace(false);
-                 $object->setContentData(\'fatal_error\',array(
-                    \'message\' => $error[\'message\'],
-                    \'file\' => $error[\'file\'],
-                    \'line\' => $error[\'line\'],
-                    \'trace\' => Mage::helper(\'M2ePro/Module_Exception\')->getFatalStackTraceInfo($stackTrace)
-                 ));
-             }';
-
-        $shutdownDeleteFunction = create_function('', $functionCode);
+            if (in_array((int)$error['type'], array(E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR))) {
+                $stackTrace = @debug_backtrace(false);
+                $object->setContentData('fatal_error', array(
+                    'message' => $error['message'],
+                    'file'    => $error['file'],
+                    'line'    => $error['line'],
+                    'trace'   => Mage::helper('M2ePro/Module_Exception')->getFatalStackTraceInfo($stackTrace)
+                ));
+            }
+        };
         register_shutdown_function($shutdownDeleteFunction);
 
         return true;


### PR DESCRIPTION
`create_function` is deprecated in PHP 7.2 (see https://secure.php.net/manual/de/migration72.deprecated.php#migration72.deprecated.create_function-function) and anonymous functions are available since PHP 5.3, so switching to them should not be an issue.